### PR TITLE
Removed lambda layer and updated python version to 3.11

### DIFF
--- a/aws-auditmanager-conformancepack/cft/aws-auditmanager-confpack.yml
+++ b/aws-auditmanager-conformancepack/cft/aws-auditmanager-confpack.yml
@@ -72,9 +72,7 @@ Resources:
       Description: CustomAuditManagerFrameworkLambda
       Handler: CustomAuditManagerFramework_Lambda.lambda_handler
       MemorySize: '256'
-      Runtime: python3.7
-      Layers:
-        - !Ref AuditManagerLayer
+      Runtime: python3.11
       Environment:
         Variables:
           SourceAccountId : !Ref 'AWS::AccountId'
@@ -82,21 +80,6 @@ Resources:
           S3Bucket: !Ref SourceBucket
 
       Timeout: 300
-
-#Lambda Layer for AWS Audit Manager
-  AuditManagerLayer:
-    Type: AWS::Lambda::LayerVersion
-    Properties:
-      CompatibleRuntimes:
-        - python3.6
-        - python3.7
-        - python3.8
-      Content:
-        S3Bucket: !Ref SourceBucket
-        S3Key: auditmanagerlayer.zip
-      Description: Boto3 layer for audit manager
-      LayerName: AuditManagerLayer
-      LicenseInfo: MIT
 
 #IAM Role for the CustomAuditManagerFramework Lambda
   CustomAuditManagerFrameworkLambdaRole:


### PR DESCRIPTION
* Issue #1 

*Description of changes:*

- Updated python runtime to 3.11
- removed layer as the APIs are now available in boto3 version that lambda supports.

PS: Testing was done in the account provided by [this lab section](https://catalog.us-east-1.prod.workshops.aws/event/dashboard/en-US/workshop/evidence-collection/c-pack-to-assessment). 